### PR TITLE
Adds custom error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,21 @@ You can also create a core dump when an unhandled rejection occurs:
 ```
 require('make-promises-safe').abort = true
 ```
+
+### With custom logger
+
+You can add a custom logger to log errors in your own format. The custom logger must implement an `error` function that takes a single `Error` parameter. This defaults to `console.error`.
+
+```
+const makePromisesSafe = require('make-promises-safe');
+const logger = {
+  error: function(err) {
+    // log the err object
+  }
+};
+makePromisesSafe.logger = logger
+```
+
 ## License
 
 MIT

--- a/make-promises-safe.js
+++ b/make-promises-safe.js
@@ -3,7 +3,7 @@
 const event = 'unhandledRejection'
 
 process.on(event, function (err) {
-  console.error(err)
+  module.exports.logger.error(err)
   if (module.exports.abort) {
     process.abort()
   }
@@ -11,3 +11,5 @@ process.on(event, function (err) {
 })
 
 module.exports.abort = false
+
+module.exports.logger = console


### PR DESCRIPTION
Thanks for this library! We've added it to a few repos and it's been really helpful!

One feature that would be nice for our team would be the ability to add a custom logger. We have some standard logging formats that capture the timestamp and other information. It would be great if this handler would give us a way to use our own format.

I made this PR to add a custom logger to the library and updated the README with the usage. Let me know what you think!

Thanks again!